### PR TITLE
Tweaks to support production builds

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -28,6 +28,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: yarn install, build, and test
       env:
+        CLIENT_FILES_PATH: concourse-client/build
         AUTH_SECRET: embarrasing photo of spongebob at the christmas party
         AUTH_TKN_LIFETIME: 5m
         DB_URI: mongodb://root:password@localhost:27017/admin
@@ -36,6 +37,7 @@ jobs:
       run: |
         echo 'export default null' > ./concourse-server/config/config.js
         yarn install
+        yarn build
         yarn backend-coverage
         yarn backend-gh-coverage-report
     - uses: codecov/codecov-action@v1

--- a/concourse-server/app.js
+++ b/concourse-server/app.js
@@ -55,6 +55,7 @@ app.use(cookieParser());
 app.use('/api/v1/voices', citizen_voice_router)
 app.use('/api/v1/login', authenticaion_router)
 app.use('/api/v1/users', user_router)
+app.use(express.static(process.env.CLIENT_FILES_PATH || config.client_files_path))
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/concourse-server/config/config.example.js
+++ b/concourse-server/config/config.example.js
@@ -27,6 +27,8 @@ export default {
 	// Port to run the server on
 	port: 5000, // PORT
 
+	client_files_path: 'concourse-client/build', // CLIENT_FILES_PATH
+
 	ssl: {
 		// Set to true to disable SSL.
 		disabled: false, // SSL_DISABLED

--- a/concourse-server/package.json
+++ b/concourse-server/package.json
@@ -12,9 +12,12 @@
   "scripts": {
     "start": "nodemon ./bin/www",
     "test": "mocha-parallel-tests --require babel-core/register --reporter nyan --exit",
-    "test-sync": "mocha --require babel-core/register --exit"
+    "test-sync": "mocha --require babel-core/register --exit",
+    "build": "babel -d ./build ./bin/www ."
   },
   "dependencies": {
+    "babel": "^6.23.0",
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
     "bcrypt": "^3.0.4-napi",

--- a/concourse-server/public/stylesheets/style.css
+++ b/concourse-server/public/stylesheets/style.css
@@ -1,8 +1,0 @@
-body {
-  padding: 50px;
-  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
-}
-
-a {
-  color: #00B7FF;
-}

--- a/package.json
+++ b/package.json
@@ -17,9 +17,12 @@
 		"server": "yarn workspace concourse-server start",
 		"start": "concurrently --kill-others-on-fail \"yarn server\"  \"yarn client\"",
 		"frontend-build": "yarn workspace concourse-client build",
+		"backend-build": "yarn workspace concourse-server build",
+		"build": "concurrently --kill-others-on-fail \"yarn frontend-build\" \"yarn backend-build\"",
 		"backend-test": "yarn workspace concourse-server test",
 		"backend-coverage": "yarn workspace concourse-server nyc yarn test-sync",
-		"backend-gh-coverage-report": "yarn workspace concourse-server nyc report --reporter=text-lcov > coverage.lcov"
+		"backend-gh-coverage-report": "yarn workspace concourse-server nyc report --reporter=text-lcov > coverage.lcov",
+		"deploy": "yarn install && yarn build && yarn workspace concourse-server start"
 	},
 	"dependencies": {
 		"concurrently": "^5.0.1",


### PR DESCRIPTION
+ The backend server is now set up to serve the static files produced by the frontend
  + Note that a new configuration variable (CILENT_FILES_PATH) has been added. This should point to the path (relative to the place where the server executable is being run from) where the static files to serve have been found

+ To support running on older nodejs verisons (<nodejs13), babel has been set up to build the backend files
  + Build targets have been shifted around. `yarn frontend-build` now builds the frontend, `yarn backend-build` builds the backend, and `yarn build` builds both. `yarn deploy` is a shortcut to install dependencies, build the frontend and backend, and start the backend server.